### PR TITLE
Compat mode

### DIFF
--- a/lib/Jojo/Role.pm
+++ b/lib/Jojo/Role.pm
@@ -23,6 +23,8 @@ use constant COMPAT_MODE => !LEXICAL_SUBS && ($ENV{JOJO_ROLE_COMPAT} || 0);
 BEGIN {
   *EXPORT_TO = do { require Importer::Zim; Importer::Zim->can('export_to') }
     if COMPAT_MODE;
+  do { require Sub::Inject; Sub::Inject->VERSION('0.3.0') }
+    if !COMPAT_MODE && !LEXICAL_SUBS;
 }
 
 # Aliasing of Role::Tiny symbols


### PR DESCRIPTION
Compat mode is for when `Sub::Inject` is not available
(eg. no available compiler or packed scripts).
It must be explicitly requested with the environment
variable
```
  JOJO_ROLE_COMPAT=1
```
and Importer::Zim will be required. 

Compat mode is ignored if `Sub::Inject~0.3.0` is available.